### PR TITLE
preview list of tasks before publishing

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -134,6 +134,9 @@ class Conversation:
         elif msg.lower().startswith("publish"):
             self.publish()
             self.current_status = self.WaitingForStart
+        elif msg.lower().startswith("preview"):
+            self.preview()
+            self.render_task_list()
 
         elif msg.startswith("-"):
             lines = msg.strip().split("\n")

--- a/bot.py
+++ b/bot.py
@@ -136,7 +136,7 @@ class Conversation:
             self.current_status = self.WaitingForStart
         elif msg.lower().startswith("preview"):
             self.preview()
-            self.render_task_list()
+            self.render_task_list(presentation=True)
 
         elif msg.startswith("-"):
             lines = msg.strip().split("\n")


### PR DESCRIPTION
fixes #13 
@frk2 I wasn't able to test this, but since your code is so easy to follow, I leveraged the existing `render_task_list` method to provide a preview of the tasks one is about to publish
